### PR TITLE
Fix null pointer exception for ODT file with empty settings.xml data

### DIFF
--- a/src/org/jopendocument/dom/ODSingleXMLDocument.java
+++ b/src/org/jopendocument/dom/ODSingleXMLDocument.java
@@ -345,8 +345,11 @@ public class ODSingleXMLDocument extends ODXMLDocument implements Cloneable {
     private static void prependToRoot(Document settings, final Element root) {
         if (settings != null) {
             copyNS(settings, root.getDocument());
-            final Element officeSettings = (Element) settings.getRootElement().getChildren().get(0);
-            root.addContent(0, (Element) officeSettings.clone());
+            List children = settings.getRootElement().getChildren();
+            if(children != null && !children.isEmpty()) {
+                final Element officeSettings = (Element) children.get(0);
+                root.addContent(0, (Element) officeSettings.clone());
+            }
         }
     }
 


### PR DESCRIPTION
ODT files generated automatically were seen to have settings.xml files with no content (just the namespace).

This pull request avoids a null pointer exception so that processing can continue.